### PR TITLE
Loosen `Clippy` Version Restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "colonize"
 version = "0.0.2"
 dependencies = [
  "cgmath 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "colonize_utility 0.0.1",
  "colonize_world 0.0.1",
  "fps_counter 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.66"
+version = "0.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,7 +134,7 @@ name = "colonize_utility"
 version = "0.0.1"
 dependencies = [
  "cgmath 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ version = "0.0.1"
 dependencies = [
  "array 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "colonize_utility 0.0.1",
  "noise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -833,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rgframework"
 version = "0.0.1"
 dependencies = [
- "clippy 0.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ time = "0.1.35"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.66"
+version = "0.0"
 
 [dependencies.colonize_utility]
 path = "utility"

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -23,7 +23,7 @@ serde = "0.7.4"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.66"
+version = "0.0"
 
 [dependencies.serde_macros]
 optional = true

--- a/utility/Cargo.toml
+++ b/utility/Cargo.toml
@@ -11,7 +11,7 @@ cgmath = "0.9.1"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.66"
+version = "0.0"
 
 [features]
 nightly-testing = ["clippy"]

--- a/world/Cargo.toml
+++ b/world/Cargo.toml
@@ -28,7 +28,7 @@ path = "../utility"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.66"
+version = "0.0"
 
 [dependencies.serde_macros]
 optional = true


### PR DESCRIPTION
Loosen `Clippy` version restriction from `0.0.66` to `0.0`.
Update `Clippy` from `0.0.66` to `0.0.67`.