### PR TITLE
Fix Struct Deserialization

### DIFF
--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -24,6 +24,7 @@ pub use util::RustcSerializeWrapper;
 pub mod backend;
 mod bindings;
 pub mod draw;
+mod macros;
 mod scene;
 mod scene_manager;
 mod util;

--- a/framework/src/macros.rs
+++ b/framework/src/macros.rs
@@ -1,0 +1,35 @@
+#[macro_export]
+macro_rules! create_type_parsing_impls {
+    ($type_name:ident,
+     $parsed_type_name:ident,
+     $($i:ident: $ty:ty, $def:expr);+ $(;)*) => (
+        impl $type_name {
+            fn fill_from_parsed(mut self, parsed: $parsed_type_name) -> $type_name {
+            $(
+                if let Some(val) = parsed.$i {
+                    self.$i = val;
+                }
+            )+
+                self
+            }
+
+            pub fn from_json(json: &str) -> $type_name {
+                use serde_json;
+
+                let parsed = serde_json::from_str(json).expect("Could not parse JSON");
+                $type_name::default().fill_from_parsed(parsed)
+            }
+        }
+
+        // Template for the default struct
+        impl Default for $type_name {
+            fn default() -> Self {
+                $type_name {
+                    $(
+                        $i: $def,
+                    )+
+                }
+            }
+        }
+    )
+}

--- a/src/config.in.rs
+++ b/src/config.in.rs
@@ -1,46 +1,50 @@
 #[derive(Deserialize, Serialize)]
 pub struct Config {
-    #[serde(default)]
     /// Localization language
     pub language: String,
-    #[serde(default)]
     /// Directory in which game assets are located
     pub asset_path: String,
-    #[serde(default)]
     /// Path to the main font file, relative to the fonts directory.
     pub font_file: String,
-    #[serde(default)]
     /// Height of the window
     pub window_height: u32,
-    #[serde(default)]
     /// Width of the window
     pub window_width: u32,
-    #[serde(default)]
     /// Number of updates per second.
     /// This is the fixed update rate on average over time. If the event loop
     /// lags, it will try to catch up.
     pub ups: u64,
-    #[serde(default)]
     /// Maximum number of frames per second.
     /// The frame rate can be lower because the next frame is always scheduled
     /// from the previous frame. This causes the frames to "slip" over time.
     pub max_fps: u64,
-    #[serde(default)]
     /// Terminate the program upon recieving the ESC key
     pub exit_on_esc: bool,
-    #[serde(default)]
     /// Initialize the window in fullscreen mode
     pub fullscreen: bool,
-    #[serde(default)]
     /// Enable vsync
     pub vsync: bool,
-    #[serde(default)]
     /// Radius (in chunks) of the initially generated world
     pub initial_world_size: u32,
-    #[serde(default)]
     /// Font size for all rendered text
     pub font_size: u32,
-    #[serde(default)]
     /// Key bindings for the main game scene
     pub game_scene_key_bindings: BindingsHashMap<RustcSerializeWrapper<Key>, Action>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ParsedConfig {
+    language: Option<String>,
+    asset_path: Option<String>,
+    font_file: Option<String>,
+    window_height: Option<u32>,
+    window_width: Option<u32>,
+    ups: Option<u64>,
+    max_fps: Option<u64>,
+    exit_on_esc: Option<bool>,
+    fullscreen: Option<bool>,
+    vsync: Option<bool>,
+    initial_world_size: Option<u32>,
+    font_size: Option<u32>,
+    game_scene_key_bindings: Option<BindingsHashMap<RustcSerializeWrapper<Key>, Action>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,28 +15,26 @@ include!("config.in.rs");
 #[cfg(feature = "with-syntex")]
 include!(concat!(env!("OUT_DIR"), "/config.rs"));
 
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            language: "en_CA".to_owned(),
-            asset_path: "./assets/".to_owned(),
-            font_file: "NotoSans/NotoSans-Regular.ttf".to_owned(),
-            window_height: 800,
-            window_width: 800,
-            ups: 180,
-            max_fps: 10_000,
-            exit_on_esc: true,
-            fullscreen: false,
-            vsync: false,
-            initial_world_size: 3,
-            font_size: 16,
-            game_scene_key_bindings: BindingsHashMap::new()
-                    .add_binding(RustcSerializeWrapper::new(Key::Down), Action::Camera(CameraAction::Move(Direction::South)))
-                    .add_binding(RustcSerializeWrapper::new(Key::Comma), Action::Camera(CameraAction::Move(Direction::Down)))
-                    .add_binding(RustcSerializeWrapper::new(Key::Up), Action::Camera(CameraAction::Move(Direction::North)))
-                    .add_binding(RustcSerializeWrapper::new(Key::Left), Action::Camera(CameraAction::Move(Direction::West)))
-                    .add_binding(RustcSerializeWrapper::new(Key::Right), Action::Camera(CameraAction::Move(Direction::East)))
-                    .add_binding(RustcSerializeWrapper::new(Key::Period), Action::Camera(CameraAction::Move(Direction::Up))),
-        }
-    }
+create_type_parsing_impls! {
+    Config,
+    ParsedConfig,
+    language: String, "en_CA".to_owned();
+    asset_path: String, "./assets/".to_owned();
+    font_file: String, "NotoSans/NotoSans-Regular.ttf".to_owned();
+    window_height: u32, 800;
+    window_width: u32, 800;
+    ups: u64, 180;
+    max_fps: u64, 10_000;
+    exit_on_esc: bool, true;
+    fullscreen: bool, false;
+    vsync: bool, false;
+    initial_world_size: u32, 3;
+    font_size: u32, 16;
+    game_scene_key_bindings: BindingsHashMap<RustcSerializeWrapper<Key>, Action>, BindingsHashMap::new()
+            .add_binding(RustcSerializeWrapper::new(Key::Down), Action::Camera(CameraAction::Move(Direction::South)))
+            .add_binding(RustcSerializeWrapper::new(Key::Comma), Action::Camera(CameraAction::Move(Direction::Down)))
+            .add_binding(RustcSerializeWrapper::new(Key::Up), Action::Camera(CameraAction::Move(Direction::North)))
+            .add_binding(RustcSerializeWrapper::new(Key::Left), Action::Camera(CameraAction::Move(Direction::West)))
+            .add_binding(RustcSerializeWrapper::new(Key::Right), Action::Camera(CameraAction::Move(Direction::East)))
+            .add_binding(RustcSerializeWrapper::new(Key::Period), Action::Camera(CameraAction::Move(Direction::Up)));
 }

--- a/src/localization.in.rs
+++ b/src/localization.in.rs
@@ -1,39 +1,43 @@
 #[derive(Deserialize, Serialize)]
 pub struct Localization {
-    #[serde(default)]
     /// Colonize - Window title
     pub colonize_window_title: String,
-    #[serde(default)]
     /// GameScene - Welcome text
     pub gamescene_welcome_text: String,
-    #[serde(default)]
     /// GameScene - Debug - Cursor
     pub gamescene_debug_cursor: String,
-    #[serde(default)]
     /// GameScene - Debug - Camera
     pub gamescene_debug_camera: String,
-    #[serde(default)]
     /// GameScene - Debug - Chunk
     pub gamescene_debug_chunk: String,
-    #[serde(default)]
     /// Internal - Failed to build window
     pub internal_failed_to_build_window: String,
-    #[serde(default)]
     /// Internal - Failed to load font message
     pub internal_failed_to_load_font: String,
-    #[serde(default)]
     /// MenuScene - Menu option - Singleplayer
     pub menuscene_singleplayer: String,
-    #[serde(default)]
     /// MenuScene - Menu option - Options
     pub menuscene_options: String,
-    #[serde(default)]
     /// MenuScene - Menu option - Credits
     pub menuscene_credits: String,
-    #[serde(default)]
     /// Util - Unit - Millisecond
     pub util_unit_millisecond: String,
-    #[serde(default)]
     /// Util - Unit - FPS
     pub util_unit_fps: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ParsedLocalization {
+    pub colonize_window_title: Option<String>,
+    pub gamescene_welcome_text: Option<String>,
+    pub gamescene_debug_cursor: Option<String>,
+    pub gamescene_debug_camera: Option<String>,
+    pub gamescene_debug_chunk: Option<String>,
+    pub internal_failed_to_build_window: Option<String>,
+    pub internal_failed_to_load_font: Option<String>,
+    pub menuscene_singleplayer: Option<String>,
+    pub menuscene_options: Option<String>,
+    pub menuscene_credits: Option<String>,
+    pub util_unit_millisecond: Option<String>,
+    pub util_unit_fps: Option<String>,
 }

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -4,22 +4,19 @@ include!("localization.in.rs");
 #[cfg(feature = "with-syntex")]
 include!(concat!(env!("OUT_DIR"), "/localization.rs"));
 
-// Template for the default localization
-impl Default for Localization {
-    fn default() -> Self {
-        Localization {
-            colonize_window_title: "Colonize".to_owned(),
-            gamescene_welcome_text: "Welcome to Colonize!".to_owned(),
-            gamescene_debug_cursor: "Mouse Cursor".to_owned(),
-            gamescene_debug_camera: "Camera".to_owned(),
-            gamescene_debug_chunk: "Chunk".to_owned(),
-            internal_failed_to_build_window: "Failed to build window".to_owned(),
-            internal_failed_to_load_font: "Failed to load font".to_owned(),
-            menuscene_singleplayer: "S)ingleplayer".to_owned(),
-            menuscene_options: "O)ptions".to_owned(),
-            menuscene_credits: "C)redits".to_owned(),
-            util_unit_millisecond: "ms".to_owned(),
-            util_unit_fps: "FPS".to_owned(),
-        }
-    }
+create_type_parsing_impls! {
+    Localization,
+    ParsedLocalization,
+    colonize_window_title: String, "Colonize".to_owned();
+    gamescene_welcome_text: String, "Welcome to Colonize!".to_owned();
+    gamescene_debug_cursor: String, "Mouse Cursor".to_owned();
+    gamescene_debug_camera: String, "Camera".to_owned();
+    gamescene_debug_chunk: String, "Chunk".to_owned();
+    internal_failed_to_build_window: String, "Failed to build window".to_owned();
+    internal_failed_to_load_font: String, "Failed to load font".to_owned();
+    menuscene_singleplayer: String, "S)ingleplayer".to_owned();
+    menuscene_options: String, "O)ptions".to_owned();
+    menuscene_credits: String, "C)redits".to_owned();
+    util_unit_millisecond: String, "ms".to_owned();
+    util_unit_fps: String, "FPS".to_owned();
 }


### PR DESCRIPTION
# Issue

https://github.com/indiv0/colonize/pull/51 broke deserialization of `Config` and `Localization` because I assumed `#[serde(default)]` would use the type's `Default` impl and not the field's `Default` impl.

# PR

This (partially) reverts the change to the way it was before, but without using a macro to generate `Config` and `Localization`, as that would break compilation on stable due to the `#[derive(Deserialize, Serialize)]` attributes on the struct.

Create `create_type_parsing_impls` macro.
Fix the way `Config` `Localization` are deserialized by using the
`create_type_parsing_impls` macro from `rgframework`.
Remove `deserialize_from_file_or_default` function.