### PR TITLE
Remove Unused Macro Argument

### DIFF
--- a/framework/src/macros.rs
+++ b/framework/src/macros.rs
@@ -2,7 +2,7 @@
 macro_rules! create_type_parsing_impls {
     ($type_name:ident,
      $parsed_type_name:ident,
-     $($i:ident: $ty:ty, $def:expr);+ $(;)*) => (
+     $($i:ident, $def:expr);+ $(;)*) => (
         impl $type_name {
             fn fill_from_parsed(mut self, parsed: $parsed_type_name) -> $type_name {
             $(

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,19 +18,19 @@ include!(concat!(env!("OUT_DIR"), "/config.rs"));
 create_type_parsing_impls! {
     Config,
     ParsedConfig,
-    language: String, "en_CA".to_owned();
-    asset_path: String, "./assets/".to_owned();
-    font_file: String, "NotoSans/NotoSans-Regular.ttf".to_owned();
-    window_height: u32, 800;
-    window_width: u32, 800;
-    ups: u64, 180;
-    max_fps: u64, 10_000;
-    exit_on_esc: bool, true;
-    fullscreen: bool, false;
-    vsync: bool, false;
-    initial_world_size: u32, 3;
-    font_size: u32, 16;
-    game_scene_key_bindings: BindingsHashMap<RustcSerializeWrapper<Key>, Action>, BindingsHashMap::new()
+    language, "en_CA".to_owned();
+    asset_path, "./assets/".to_owned();
+    font_file, "NotoSans/NotoSans-Regular.ttf".to_owned();
+    window_height, 800;
+    window_width, 800;
+    ups, 180;
+    max_fps, 10_000;
+    exit_on_esc, true;
+    fullscreen, false;
+    vsync, false;
+    initial_world_size, 3;
+    font_size, 16;
+    game_scene_key_bindings, BindingsHashMap::new()
             .add_binding(RustcSerializeWrapper::new(Key::Down), Action::Camera(CameraAction::Move(Direction::South)))
             .add_binding(RustcSerializeWrapper::new(Key::Comma), Action::Camera(CameraAction::Move(Direction::Down)))
             .add_binding(RustcSerializeWrapper::new(Key::Up), Action::Camera(CameraAction::Move(Direction::North)))

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -7,16 +7,16 @@ include!(concat!(env!("OUT_DIR"), "/localization.rs"));
 create_type_parsing_impls! {
     Localization,
     ParsedLocalization,
-    colonize_window_title: String, "Colonize".to_owned();
-    gamescene_welcome_text: String, "Welcome to Colonize!".to_owned();
-    gamescene_debug_cursor: String, "Mouse Cursor".to_owned();
-    gamescene_debug_camera: String, "Camera".to_owned();
-    gamescene_debug_chunk: String, "Chunk".to_owned();
-    internal_failed_to_build_window: String, "Failed to build window".to_owned();
-    internal_failed_to_load_font: String, "Failed to load font".to_owned();
-    menuscene_singleplayer: String, "S)ingleplayer".to_owned();
-    menuscene_options: String, "O)ptions".to_owned();
-    menuscene_credits: String, "C)redits".to_owned();
-    util_unit_millisecond: String, "ms".to_owned();
-    util_unit_fps: String, "FPS".to_owned();
+    colonize_window_title, "Colonize".to_owned();
+    gamescene_welcome_text, "Welcome to Colonize!".to_owned();
+    gamescene_debug_cursor, "Mouse Cursor".to_owned();
+    gamescene_debug_camera, "Camera".to_owned();
+    gamescene_debug_chunk, "Chunk".to_owned();
+    internal_failed_to_build_window, "Failed to build window".to_owned();
+    internal_failed_to_load_font, "Failed to load font".to_owned();
+    menuscene_singleplayer, "S)ingleplayer".to_owned();
+    menuscene_options, "O)ptions".to_owned();
+    menuscene_credits, "C)redits".to_owned();
+    util_unit_millisecond, "ms".to_owned();
+    util_unit_fps, "FPS".to_owned();
 }


### PR DESCRIPTION
Remove unused `ty` argument from the `create_type_parsing_impls` macro.