### PR TITLE
Display Rendering Debug Info in Window

### DIFF
--- a/assets/localization/en_CA.json
+++ b/assets/localization/en_CA.json
@@ -1,5 +1,6 @@
 {
     "colonize_window_title": "Colonize",
+    "debug_render_info": "Render Info",
     "gamescene_welcome_text": "Welcome to Colonize!",
     "gamescene_debug_cursor": "Mouse Cursor",
     "gamescene_debug_camera": "Camera",

--- a/src/localization.in.rs
+++ b/src/localization.in.rs
@@ -2,6 +2,8 @@
 pub struct Localization {
     /// Colonize - Window title
     pub colonize_window_title: String,
+    /// Debug - Render Info
+    pub debug_render_info: String,
     /// GameScene - Welcome text
     pub gamescene_welcome_text: String,
     /// GameScene - Debug - Cursor
@@ -29,6 +31,7 @@ pub struct Localization {
 #[derive(Deserialize, Serialize)]
 struct ParsedLocalization {
     colonize_window_title: Option<String>,
+    debug_render_info: Option<String>,
     gamescene_welcome_text: Option<String>,
     gamescene_debug_cursor: Option<String>,
     gamescene_debug_camera: Option<String>,

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -8,6 +8,7 @@ create_type_parsing_impls! {
     Localization,
     ParsedLocalization,
     colonize_window_title, "Colonize".to_owned();
+    debug_render_info, "Render Info".to_owned();
     gamescene_welcome_text, "Welcome to Colonize!".to_owned();
     gamescene_debug_cursor, "Mouse Cursor".to_owned();
     gamescene_debug_camera, "Camera".to_owned();


### PR DESCRIPTION
Display rendering debug information in the window, rather than in the window title.