### PR TITLE
Cut the 0.2.0 release

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,10 @@
+[clog]
+repository = "https://github.com/indiv0/colonize"
+outfile = "CHANGELOG.md"
+from-latest-tag = true
+
+[sections]
+Performance = ["perf"]
+Improvements = ["impr", "im", "imp"]
+Documentation = ["docs"]
+Examples = ["examples"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+<a name="v0.2.0"></a>
+##  (2016-05-15)
+
+
+#### Documentation
+
+* **README:**  update `README.md` ([07cd376b](https://github.com/indiv0/colonize/commit/07cd376b496ac9c3299426e238c4ba6117d26284))
+
+#### Breaking Changes
+
+*   implement partially backend-agnostic rendering ([5acfcd49](https://github.com/indiv0/colonize/commit/5acfcd4933e765f85d7da5cae71c2ffcd612c071), closes [#22](https://github.com/indiv0/colonize/issues/22), breaks [#](https://github.com/indiv0/colonize/issues/))
+
+#### Features
+
+*   display render debug info in window ([1a590c1e](https://github.com/indiv0/colonize/commit/1a590c1e5411c75666461e4d7f9ff1a952abe2f2))
+*   implement partially backend-agnostic rendering ([5acfcd49](https://github.com/indiv0/colonize/commit/5acfcd4933e765f85d7da5cae71c2ffcd612c071), closes [#22](https://github.com/indiv0/colonize/issues/22), breaks [#](https://github.com/indiv0/colonize/issues/))
+*   move `tcod` crate import to `worldview` ([659f41a8](https://github.com/indiv0/colonize/commit/659f41a85695b1a1ac81e4b50bf42b5edd518c27))
+*   improve terrain generation ([919840dd](https://github.com/indiv0/colonize/commit/919840dd2cc5880cba27bdb4ed1ff656c61a81ef))
+*   refactor rendering code from `world` ([f1ddf577](https://github.com/indiv0/colonize/commit/f1ddf577a7eb77cd5aa1cf3a214e3735dab13506))
+*   implement 3D chunk generation ([d38b4a45](https://github.com/indiv0/colonize/commit/d38b4a45dba632d227abd8f20a4230dd29e9a6e8))
+*   refactor out `Direction` enum ([e866c025](https://github.com/indiv0/colonize/commit/e866c0255aa8a2101cd077f8e1bfedd8845db4d6))
+*   replace `Point2` with `cgmath::Point2` ([1b3313c9](https://github.com/indiv0/colonize/commit/1b3313c9ddc8d8c59a0c2ce86c0303f12e46b647))
+*   add `Camera` struct and `Command` trait ([54712b69](https://github.com/indiv0/colonize/commit/54712b6918caf1aa1c0caf05e2742ef54c7f4a19))
+*   update to latest Rustc ([c6409450](https://github.com/indiv0/colonize/commit/c64094508343f6a59a2dc13d43a8b6bf1186ad69))
+* **Localization:**  remove unnecessary pub ([7036912b](https://github.com/indiv0/colonize/commit/7036912b1c416ea51020105c68581ee31dccd07f))
+* **macro:**  remove unused macro arg ([e5224b80](https://github.com/indiv0/colonize/commit/e5224b80ff6da35873d6a949db69fa102ab796af))
+
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "colonize"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Nikita Pekin <contact@nikitapek.in>"]
 build = "build.rs"
 


### PR DESCRIPTION
Cut the 0.2.0 release.
Add a `.clog.toml` file for use with `clog-cli`.

Closes #5.