### PR TITLE
Enable `x86_64-unknown-linux-musl` Builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,12 @@ matrix:
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-musl
+      # needed to install musl-tools
+      sudo: true
+      dist: trusty
     # beta channel
     - os: osx
       rust: beta
@@ -55,6 +61,12 @@ matrix:
     - os: linux
       rust: beta
       env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: beta
+      env: TARGET=x86_64-unknown-linux-musl
+      # needed to install musl-tools
+      sudo: true
+      dist: trusty
     # nightly channel
     - os: osx
       rust: nightly
@@ -68,6 +80,12 @@ matrix:
     - os: linux
       rust: nightly
       env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: nightly
+      env: TARGET=x86_64-unknown-linux-musl
+      # needed to install musl-tools
+      sudo: true
+      dist: trusty
 
 before_install:
   - |

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,6 +10,12 @@ install_c_toolchain() {
             sudo apt-get install -y --no-install-recommends \
                  gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
             ;;
+        x86_64-unknown-linux-musl)
+            # Installs the `musl-tools` package, which is required to compile
+            # `miniz-sys` (and possibly other crates).
+            sudo apt-get install -y --no-install-recommends \
+                musl-tools
+            ;;
         *)
             # For other targets, this is handled by addons.apt.packages in .travis.yml
             ;;


### PR DESCRIPTION
Added x86_64-unknown-linux-musl builds for all the tool chains.
Enable `sudo: true` for musl builds on Travis CI so that `musl-tools` can be
installed with `apt-get`.
Set `dist: trusty` for musl Travis CI builds to build on Ubuntu Trusty.
Modified the `ci/install.sh` script to install the `musl-tool` package for the
`x86_64-unknown-linux-musl` target so that `musl-gcc` is available to certain
crates (e.g. `miniz-sys`).

Closes #60.
