### PR TITLE
Lock All Cargo Versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "colonize"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "cgmath 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,10 +12,10 @@ dependencies = [
  "piston2d-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-opengl_graphics 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rgframework 0.0.1",
- "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,6 +78,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,16 +119,16 @@ dependencies = [
  "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cocoa"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,9 +153,9 @@ dependencies = [
  "noise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -183,7 +188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -345,7 +350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -379,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -611,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -815,7 +820,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -837,9 +842,9 @@ dependencies = [
  "piston 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston2d-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -871,12 +876,12 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_codegen"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -893,15 +898,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -986,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1049,7 +1054,7 @@ name = "wayland-scanner"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "xml-rs 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1092,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ name = "colonize"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "*"
+version = "0.7.5"
 
 [build-dependencies.syntex]
 optional = true
-version = "*"
+version = "0.32.0"
 
 [dependencies]
 cgmath = "0.9.1"
@@ -24,7 +24,7 @@ piston = "0.22.1"
 piston2d-glium_graphics = "0.25.0"
 piston2d-graphics = "0.16.0"
 piston2d-opengl_graphics = "0.29.0"
-serde = "0.7.4"
+serde = "0.7.5"
 serde_json = "0.7.0"
 shader_version = "0.2.1"
 time = "0.1.35"
@@ -35,18 +35,21 @@ version = "0.0"
 
 [dependencies.colonize_utility]
 path = "utility"
+version = "0.0.1"
 
 [dependencies.colonize_world]
 default-features = false
 path = "world"
+version = "0.0.1"
 
 [dependencies.rgframework]
 default-features = false
 path = "framework"
+version = "0.0.1"
 
 [dependencies.serde_macros]
 optional = true
-version = "0.7.4"
+version = "0.7.5"
 
 [features]
 default = ["with-syntex"]

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -9,11 +9,11 @@ description = "A Rust game framework built upon Piston"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "*"
+version = "0.7.5"
 
 [build-dependencies.syntex]
 optional = true
-version = "*"
+version = "0.32.0"
 
 [dependencies]
 piston = "0.22.1"
@@ -27,7 +27,7 @@ version = "0.0"
 
 [dependencies.serde_macros]
 optional = true
-version = "0.7.4"
+version = "0.7.5"
 
 [features]
 default = ["with-syntex"]

--- a/world/Cargo.toml
+++ b/world/Cargo.toml
@@ -9,11 +9,11 @@ build = "build.rs"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "*"
+version = "0.7.5"
 
 [build-dependencies.syntex]
 optional = true
-version = "*"
+version = "0.32.0"
 
 [dependencies]
 cgmath = "0.9.1"
@@ -32,7 +32,7 @@ version = "0.0"
 
 [dependencies.serde_macros]
 optional = true
-version = "0.7.4"
+version = "0.7.5"
 
 [features]
 default = ["with-syntex"]


### PR DESCRIPTION
Update `colonize` version to `0.1.0`.
Lock `serde`, `serde_codegen`, and `serde_macros` versions to 0.7.5.
Lock `rgframework`, `utility`, and `world` crate versions to 0.0.1.
Lock `syntex` version to 0.32.0.