### PR TITLE
Removed double entry in utility/Cargo.toml

### DIFF
--- a/utility/Cargo.toml
+++ b/utility/Cargo.toml
@@ -13,8 +13,6 @@ keywords = [
 ]
 license = "MIT/Apache-2.0"
 
-description = "Utilities for general roguelike creation"
-
 [dependencies]
 cgmath = "0.9.1"
 


### PR DESCRIPTION
Removed a double description entry in `utility/Cargo.toml`.

I removed this entry, because it was the older one of them, first time double entry has been seen was commit 8e6dcdb91bdf32ff7d750d9d361cc6e7d9d543e1.